### PR TITLE
Using go map for node lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ go get github.com/igrmk/treemap/v2
 |:------------------------------:|:---------:|
 |             `Set`              | O(log*N*) |
 |             `Del`              | O(log*N*) |
-|             `Get`              | O(log*N*) |
-|           `Contains`           | O(log*N*) |
+|             `Get`              |   O(1)    |
+|           `Contains`           |   O(1)    |
 |             `Len`              |   O(1)    |
 |            `Clear`             |   O(1)    |
 |            `Range`             | O(log*N*) |

--- a/v2/treemap.go
+++ b/v2/treemap.go
@@ -100,7 +100,7 @@ func (t *TreeMap[Key, Value]) Set(key Key, value Value) {
 }
 
 // Del deletes the value.
-// Complexity: O(log N).
+// Complexity: O(1).
 func (t *TreeMap[Key, Value]) Del(key Key) {
 	z := t.findNode(key)
 	if z == nil {
@@ -128,7 +128,7 @@ func (t *TreeMap[Key, Value]) Clear() {
 }
 
 // Get retrieves a value from a map for specified key and reports if it exists.
-// Complexity: O(log N).
+// Complexity: O(1).
 func (t *TreeMap[Key, Value]) Get(id Key) (Value, bool) {
 	node := t.findNode(id)
 	if node == nil {
@@ -138,7 +138,7 @@ func (t *TreeMap[Key, Value]) Get(id Key) (Value, bool) {
 }
 
 // Contains checks if key exists in a map.
-// Complexity: O(log N)
+// Complexity: O(1)
 func (t *TreeMap[Key, Value]) Contains(id Key) bool { return t.findNode(id) != nil }
 
 // Range returns a pair of iterators that you can use to go through all the keys in the range [from, to].

--- a/v2/treemap.go
+++ b/v2/treemap.go
@@ -115,6 +115,7 @@ func (t *TreeMap[Key, Value]) Del(key Key) {
 	}
 	t.count--
 	removeNode(t.endNode.left, z)
+	delete(t.nodeRef, key)
 }
 
 // Clear clears the map.

--- a/v2/treemap.go
+++ b/v2/treemap.go
@@ -100,7 +100,7 @@ func (t *TreeMap[Key, Value]) Set(key Key, value Value) {
 }
 
 // Del deletes the value.
-// Complexity: O(1).
+// Complexity: O(logN).
 func (t *TreeMap[Key, Value]) Del(key Key) {
 	z := t.findNode(key)
 	if z == nil {

--- a/v2/treemap.go
+++ b/v2/treemap.go
@@ -100,7 +100,7 @@ func (t *TreeMap[Key, Value]) Set(key Key, value Value) {
 }
 
 // Del deletes the value.
-// Complexity: O(logN).
+// Complexity: O(log N).
 func (t *TreeMap[Key, Value]) Del(key Key) {
 	z := t.findNode(key)
 	if z == nil {

--- a/v2/treemap_test.go
+++ b/v2/treemap_test.go
@@ -26,6 +26,11 @@ func TestGet(t *testing.T) {
 	testGet(t, NewWithKeyCompare[int, string](less))
 }
 
+func TestDuplicate(t *testing.T) {
+	testDuplicate(t, New[int, string]())
+	testDuplicate(t, NewWithKeyCompare[int, string](less))
+}
+
 func TestContains(t *testing.T) {
 	testContains(t, New[int, string]())
 	testContains(t, NewWithKeyCompare[int, string](less))
@@ -463,5 +468,28 @@ func testRangeSingle(t *testing.T, tr *TreeMap[int, string]) {
 	}
 	if !visited {
 		t.Error("single element 'b' should be found")
+	}
+}
+
+func testDuplicate(t *testing.T, tr *TreeMap[int, string]) {
+	tr.Set(65, "A")
+	tr.Set(65, "a")
+
+	if tr.Len() != 1 {
+		t.Error("count should be 1")
+	}
+
+	if v, _ := tr.Get(65); v != "a" {
+		t.Error("value should be 'a'")
+	}
+
+	tr.Del(65)
+
+	if tr.Len() != 0 {
+		t.Error("count should be 0")
+	}
+
+	if v, ok := tr.Get(65); v != "" || ok {
+		t.Error("value should be ''")
 	}
 }


### PR DESCRIPTION
What this PR does?

- Adds a go map `key` -> `node reference` to `Treemap`. This basically optimises node lookups based on keys, reducing the complexity from `O(logN)` to `O(1)`.
- Increases the complexity of `Set` slightly due to the addition of one more data-strucutre in the code flow.
- Adds a unit test to test whether duplicate entries behave as expected.

How has this been tested?

- Unit tests.
- Using it as a library inside a code to check whether the functionalities are not broken.

Benchmarking results?

On `master`
```
goos: darwin
goarch: arm64
pkg: github.com/igrmk/treemap/v2
BenchmarkSeqSet
BenchmarkSeqSet-12           854     1205471 ns/op    640008 B/op    10000 allocs/op
BenchmarkSeqGet
BenchmarkSeqGet-12      21092348          56.98 ns/op        0 B/op        0 allocs/op
BenchmarkSeqIter
BenchmarkSeqIter-12        29380       38979 ns/op         0 B/op        0 allocs/op
BenchmarkRndSet
BenchmarkRndSet-12           943     1276197 ns/op    637323 B/op     9958 allocs/op
BenchmarkRndGet
BenchmarkRndGet-12      29470995          40.32 ns/op        0 B/op        0 allocs/op
BenchmarkRndIter
BenchmarkRndIter-12        15868       78945 ns/op         0 B/op        0 allocs/op
```


On `kkavish/treemap` -> `kkavish/fast-get`
```
goos: darwin
goarch: arm64
pkg: github.com/igrmk/treemap/v2
BenchmarkSeqSet
BenchmarkSeqSet-12           648     1820143 ns/op   1646977 B/op    19806 allocs/op
BenchmarkSeqGet
BenchmarkSeqGet-12      50108742          24.28 ns/op        0 B/op        0 allocs/op
BenchmarkSeqIter
BenchmarkSeqIter-12        28593       42258 ns/op         0 B/op        0 allocs/op
BenchmarkRndSet
BenchmarkRndSet-12           583     2052893 ns/op   1667299 B/op    20065 allocs/op
BenchmarkRndGet
BenchmarkRndGet-12      50770101          23.57 ns/op        0 B/op        0 allocs/op
BenchmarkRndIter
BenchmarkRndIter-12        16020       75424 ns/op         0 B/op        0 allocs/op
PASS
```

P.S. - Looking forward for comments and suggestions to learn more.